### PR TITLE
Add fees optional param

### DIFF
--- a/lib/docs/docs_helper.dart
+++ b/lib/docs/docs_helper.dart
@@ -91,6 +91,7 @@ class DocsHelper {
     @required String documentId,
     @required Wallet wallet,
     String proof = "",
+    StdFee fee,
   }) {
     final msg = MsgSendDocumentReceipt(
       CommercioDocReceipt(
@@ -102,7 +103,7 @@ class DocsHelper {
         senderDid: wallet.bech32Address,
       ),
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 
   /// Returns the list of all the [CommercioDocReceipt] that

--- a/lib/id/id_helper.dart
+++ b/lib/id/id_helper.dart
@@ -22,21 +22,18 @@ class IdHelper {
   /// Performs a transaction setting the specified [didDocument] as being
   /// associated with the address present inside the specified [wallet].
   static Future<TransactionResult> setDidDocument(
-    DidDocument didDocument,
-    Wallet wallet,
-  ) {
+      DidDocument didDocument, Wallet wallet,
+      {StdFee fee}) {
     final msg = MsgSetDidDocument(didDocument: didDocument);
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 
   /// Creates a new Did deposit request for the given [recipient] and of the given [amount].
   /// Signs everything that needs to be signed (i.e. the signature JSON inside the payload) with the
   /// private key contained inside the given [wallet].
   static Future<TransactionResult> requestDidDeposit(
-    String recipient,
-    List<StdCoin> amount,
-    Wallet wallet,
-  ) async {
+      String recipient, List<StdCoin> amount, Wallet wallet,
+      {StdFee fee}) async {
     // Get the timestamp
     var timestamp = getTimeStamp();
 
@@ -65,17 +62,15 @@ class IdHelper {
       encryptionKey: HEX.encode(result.encryptedAesKey),
       senderDid: wallet.bech32Address,
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 
   /// Creates a new Did power up request for the given [pairwiseDid] and of the given [amount].
   /// Signs everything that needs to be signed (i.e. the signature JSON inside the payload) with the
   /// private key contained inside the given [wallet].
   static Future<TransactionResult> requestDidPowerUp(
-    String pairwiseDid,
-    List<StdCoin> amount,
-    Wallet wallet,
-  ) async {
+      String pairwiseDid, List<StdCoin> amount, Wallet wallet,
+      {StdFee fee}) async {
     // Get the timestamp
     final timestamp = getTimeStamp();
 
@@ -103,6 +98,6 @@ class IdHelper {
       powerUpProof: HEX.encode(result.encryptedProof),
       encryptionKey: HEX.encode(result.encryptedAesKey),
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 }

--- a/lib/membership/membership_helper.dart
+++ b/lib/membership/membership_helper.dart
@@ -4,26 +4,23 @@ import 'package:sacco/sacco.dart';
 /// Allows to easily perform CommercioMEMBERSHIP related operations.
 class MembershipHelper {
   /// Sends a new transaction in order to invite the given [userDid].
-  static Future<TransactionResult> inviteUser(
-    String userDid,
-    Wallet wallet,
-  ) async {
+  static Future<TransactionResult> inviteUser(String userDid, Wallet wallet,
+      {StdFee fee}) async {
     final msg = MsgInviteUser(
       recipientDid: userDid,
       senderDid: wallet.bech32Address,
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 
   /// Buys the membership with the given [membershipType].
   static Future<TransactionResult> buyMembership(
-    MembershipType membershipType,
-    Wallet wallet,
-  ) async {
+      MembershipType membershipType, Wallet wallet,
+      {StdFee fee}) async {
     final msg = MsgBuyMembership(
       membershipType: membershipType,
       buyerDid: wallet.bech32Address,
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 }

--- a/lib/mint/mint_helper.dart
+++ b/lib/mint/mint_helper.dart
@@ -4,25 +4,27 @@ import 'package:sacco/sacco.dart';
 /// Allows to easily perform CommercioMINT related transactions.
 class MintHelper {
   /// Opens a new CDP depositing the given Commercio Token [amount].
-  static Future<TransactionResult> openCdp(int amount, Wallet wallet) {
+  static Future<TransactionResult> openCdp(int amount, Wallet wallet,
+      {StdFee fee}) {
+    final depositAmount = fee.amount
+        .map((stdCoin) => StdCoin(
+            denom: stdCoin.denom,
+            amount: (stdCoin.amount * 1000000).toString()))
+        .toList();
     final msg = MsgOpenCdp(
-      depositAmount: [
-        StdCoin(
-          denom: "ucommercio",
-          amount: (amount * 1000000).toString(),
-        )
-      ],
+      depositAmount: depositAmount,
       signerDid: wallet.bech32Address,
     );
     return TxHelper.createSignAndSendTx([msg], wallet);
   }
 
   /// Closes the CDP having the given [timestamp].
-  static Future<TransactionResult> closeCdp(int timestamp, Wallet wallet) {
+  static Future<TransactionResult> closeCdp(int timestamp, Wallet wallet,
+      {StdFee fee}) {
     final msg = MsgCloseCdp(
       timeStamp: timestamp,
       signerDid: wallet.bech32Address,
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 }

--- a/lib/mint/mint_helper.dart
+++ b/lib/mint/mint_helper.dart
@@ -6,16 +6,16 @@ class MintHelper {
   /// Opens a new CDP depositing the given Commercio Token [amount].
   static Future<TransactionResult> openCdp(int amount, Wallet wallet,
       {StdFee fee}) {
-    final depositAmount = fee.amount
-        .map((stdCoin) => StdCoin(
-            denom: stdCoin.denom,
-            amount: (stdCoin.amount * 1000000).toString()))
-        .toList();
     final msg = MsgOpenCdp(
-      depositAmount: depositAmount,
+      depositAmount: [
+        StdCoin(
+          denom: "ucommercio",
+          amount: (amount * 1000000).toString(),
+        )
+      ],
       signerDid: wallet.bech32Address,
     );
-    return TxHelper.createSignAndSendTx([msg], wallet);
+    return TxHelper.createSignAndSendTx([msg], wallet, fee: fee);
   }
 
   /// Closes the CDP having the given [timestamp].

--- a/lib/tx/tx_helper.dart
+++ b/lib/tx/tx_helper.dart
@@ -2,15 +2,22 @@ import 'package:sacco/sacco.dart';
 
 /// Allows to easily perform common transaction operations.
 class TxHelper {
+  static const defaultGas = "200000";
+  static const defaultDenom = "ucommercio";
+  static const defaultAmount = "10000";
+
   /// Creates a transaction having the given [msgs] and [fee] inside,
   /// signs it with the given [Wallet] and sends it to the blockchain.
   static Future<TransactionResult> createSignAndSendTx(
     List<StdMsg> msgs,
     Wallet wallet, {
-    StdFee fee = const StdFee(
-        gas: "200000",
-        amount: [const StdCoin(denom: "ucommercio", amount: "100")]),
+    StdFee fee,
   }) async {
+    fee = fee ??
+        const StdFee(gas: defaultGas, amount: [
+          const StdCoin(denom: defaultDenom, amount: defaultAmount)
+        ]);
+
     final stdTx = TxBuilder.buildStdTx(stdMsgs: msgs, fee: fee);
     final signedTx = await TxSigner.signStdTx(wallet: wallet, stdTx: stdTx);
     return TxSender.broadcastStdTx(wallet: wallet, stdTx: signedTx);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -462,7 +462,7 @@ packages:
       name: sacco
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   asn1lib: ^0.5.13
 
   # Crypto utils
-  sacco: ^0.1.0
+  sacco: ^0.1.2
   encrypt: ^3.3.1
   ed25519_hd_key: ^1.0.1
   pointycastle: ^1.0.1


### PR DESCRIPTION
This pull request adds a `StdFee` parameter to helper methods that the helper `TxHelper.createSignAndSendTx()` can receive a custom `StdFee`. Also, in the `TxHelper` class the default parameters are now set as public `static const` fields.

The tests passed successfully but when I tried to write some for modified helper methods I found myself unable to mock the internal implementation, for example the `http.Client()` in `TxHelper`. The only solution I thought is to add a method that can be used to inject the internal implementation in, at least, `TxHelper` but this choice will change the API.

Closes #4 